### PR TITLE
Use configured CKAN sysadmin for DataPusher token

### DIFF
--- a/ckan/docker-entrypoint.d/01_setup_datapusher.sh
+++ b/ckan/docker-entrypoint.d/01_setup_datapusher.sh
@@ -4,8 +4,19 @@ if [[ $CKAN__PLUGINS == *"datapusher"* ]]; then
    # Datapusher settings have been configured in the .env file
    # Set API token if necessary
    if [ -z "$CKAN__DATAPUSHER__API_TOKEN" ] ; then
+      # Determine which user will own the DataPusher token
+      SYSADMIN_NAME=${CKAN_SYSADMIN_NAME:-ckan_admin}
+
+      # Ensure the sysadmin user exists (it may not if the name was customized)
+      if ! ckan -c "$CKAN_INI" user show "$SYSADMIN_NAME" >/dev/null 2>&1; then
+         ckan -c "$CKAN_INI" user add "$SYSADMIN_NAME" \
+            password="${CKAN_SYSADMIN_PASSWORD}" \
+            email="${CKAN_SYSADMIN_EMAIL}"
+         ckan -c "$CKAN_INI" sysadmin add "$SYSADMIN_NAME"
+      fi
+
       echo "Set up ckan.datapusher.api_token in the CKAN config file"
-      ckan config-tool $CKAN_INI "ckan.datapusher.api_token=$(ckan -c $CKAN_INI user token add ckan_admin datapusher | tail -n 1 | tr -d '\t')"
+      ckan config-tool $CKAN_INI "ckan.datapusher.api_token=$(ckan -c $CKAN_INI user token add $SYSADMIN_NAME datapusher | tail -n 1 | tr -d '\t')"
    fi
 else
    echo "Not configuring DataPusher"

--- a/ckan/setup/start_ckan.sh.override
+++ b/ckan/setup/start_ckan.sh.override
@@ -18,8 +18,10 @@ fi
 # Run the prerun script to init CKAN and create the default admin user
 sudo -u ckan -EH python3 prerun.py
 
+# Ensure the DataPusher token uses the configured sysadmin user
+SYSADMIN_NAME=${CKAN_SYSADMIN_NAME:-ckan_admin}
 echo "Set up ckan.datapusher.api_token in the CKAN config file"
-ckan config-tool $CKAN_INI "ckan.datapusher.api_token=$(ckan -c $CKAN_INI user token add ckan_admin datapusher | tail -n 1 | tr -d '\t')"
+ckan config-tool $CKAN_INI "ckan.datapusher.api_token=$(ckan -c $CKAN_INI user token add $SYSADMIN_NAME datapusher | tail -n 1 | tr -d '\t')"
 
 # Run any startup scripts provided by images extending this one
 if [[ -d "/docker-entrypoint.d" ]]

--- a/ckan/setup/start_ckan_development.sh.override
+++ b/ckan/setup/start_ckan_development.sh.override
@@ -76,8 +76,10 @@ ckan config-tool $SRC_DIR/ckan/test-core.ini \
 # Run the prerun script to init CKAN and create the default admin user
 sudo -u ckan -EH python3 prerun.py
 
+# Ensure the DataPusher token uses the configured sysadmin user
+SYSADMIN_NAME=${CKAN_SYSADMIN_NAME:-ckan_admin}
 echo "Set up ckan.datapusher.api_token in the CKAN config file"
-ckan config-tool $CKAN_INI "ckan.datapusher.api_token=$(ckan -c $CKAN_INI user token add ckan_admin datapusher | tail -n 1 | tr -d '\t')"
+ckan config-tool $CKAN_INI "ckan.datapusher.api_token=$(ckan -c $CKAN_INI user token add $SYSADMIN_NAME datapusher | tail -n 1 | tr -d '\t')"
 
 # Run any startup scripts provided by images extending this one
 if [[ -d "/docker-entrypoint.d" ]]


### PR DESCRIPTION
## Summary
- ensure datapusher API token is created for the configured CKAN_SYSADMIN_NAME user
- create the sysadmin user if missing before generating token

## Testing
- `bash -n ckan/docker-entrypoint.d/01_setup_datapusher.sh`
- `bash -n ckan/setup/start_ckan.sh.override`
- `bash -n ckan/setup/start_ckan_development.sh.override`
